### PR TITLE
Fix package.json 'main' field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-pstate",
   "version": "0.0.4",
   "description": "",
-  "main": "gulpfile.js",
+  "main": "./dist/react-pstate.js",
   "repository": "https://github.com/mgechev/react-pstate",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Nice library!

Just noticed that `package.json`'s `main` field was pointing to the project's `gulpfile`. This way, people that were downloading this project via `npm` and using `browserify` or `webpack` would not be able to import it like:

``` javascript
var ReactPersistentState = require('react-pstate');
```

They would instead have to do:

``` javascript
var ReactPersistentState = require('react-pstate/dist/react-pstate');
// or
var ReactPersistentState = require('react-pstate/dist/react-pstate.min');
```
